### PR TITLE
feat: implement checked-in builders counter display

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -6,7 +6,7 @@ import { BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import { useScaffoldReadContract } from "~~/hooks/scaffold-eth";
 
 const Home: NextPage = () => {
-  const { data: checkedInCount } = useScaffoldReadContract({
+  const { data: checkedInCount, isLoading } = useScaffoldReadContract({
     contractName: "BatchRegistry",
     functionName: "checkedInCounter",
   });
@@ -22,7 +22,11 @@ const Home: NextPage = () => {
           <p className="text-center text-lg">Get started by taking a look at your batch GitHub repository.</p>
           <p className="text-lg flex gap-2 justify-center">
             <span className="font-bold">Checked in builders count:</span>
-            <span>{checkedInCount?.toString() || "0"}</span>
+            {isLoading ? (
+              <span className="loading loading-spinner loading-sm"></span>
+            ) : (
+              <span>{checkedInCount?.toString()}</span>
+            )}
           </p>
         </div>
 

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -3,8 +3,14 @@
 import Link from "next/link";
 import type { NextPage } from "next";
 import { BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import { useScaffoldReadContract } from "~~/hooks/scaffold-eth";
 
 const Home: NextPage = () => {
+  const { data: checkedInCount } = useScaffoldReadContract({
+    contractName: "BatchRegistry",
+    functionName: "checkedInCounter",
+  });
+
   return (
     <>
       <div className="flex items-center flex-col grow pt-10">
@@ -16,7 +22,7 @@ const Home: NextPage = () => {
           <p className="text-center text-lg">Get started by taking a look at your batch GitHub repository.</p>
           <p className="text-lg flex gap-2 justify-center">
             <span className="font-bold">Checked in builders count:</span>
-            <span>To Be Implemented</span>
+            <span>{checkedInCount?.toString() || "0"}</span>
           </p>
         </div>
 


### PR DESCRIPTION
## Description

Implemented the checked-in builders counter display on the homepage. This replaces the "To Be implemented" placeholder with the actual count of builders who have checked in to the BatchRegistry contract.

Changes made:
- Added `useScaffoldReadContract` hook to read the `checkedInCounter` from BatchRegistry contract
- Updated the display to show the actual count with a fallback to "0"
- The counter updates automatically when new builders check in

Screenshot:
<img width="1280" alt="Screenshot 2025-05-09 at 11 25 59 AM" src="https://github.com/user-attachments/assets/88e03755-2cbb-4e2e-bab2-b3910f01d9d8" />


## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues
closes (#5 ) 

This implements part of the batch16.buidlguidl.com setup requirements.

Your ENS/address: 0x208B2660e5F62CDca21869b389c5aF9E7f0faE89